### PR TITLE
Update float-cmp to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ repository = "https://github.com/RazrFalcon/svgtypes"
 members = ["benches"]
 
 [dependencies]
-float-cmp = { version = "0.8", default-features = false, features = ["std"] }
+float-cmp = { version = "0.9", default-features = false, features = ["std"] }
 siphasher = "0.3"


### PR DESCRIPTION
This update does not require any code changes. All tests still passed on my system with `cargo test`.