### PR TITLE
Add support for parsing CSS variables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ mod points;
 mod stream;
 mod transform;
 mod transform_origin;
+mod variable;
 mod viewbox;
 
 use crate::stream::{ByteExt, Stream};

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -1,14 +1,18 @@
 use std::str::FromStr;
 
-use crate::{Color, Error, Stream};
+use crate::{variable::{VariableFallback, VariableFunction}, Color, Error, Stream};
 
 /// Representation of the fallback part of the [`<paint>`] type.
 ///
 /// Used by the [`Paint`](enum.Paint.html) type.
 ///
 /// [`<paint>`]: https://www.w3.org/TR/SVG2/painting.html#SpecifyingPaint
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum PaintFallback {
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum PaintFallback<'a> {
+    /// An empty value.
+    /// 
+    /// Rule should be treated as invalid.
+    Empty,
     /// The `none` value.
     None,
     /// The `currentColor` value.
@@ -17,6 +21,40 @@ pub enum PaintFallback {
     ///
     /// [`<color>`]: https://www.w3.org/TR/css-color-3/
     Color(Color),
+    /// A `var()` function fallback.
+    /// 
+    /// See [`VariableFunction`] for details.
+    Variable(&'a str, Option<Box<PaintFallback<'a>>>),
+}
+
+impl<'a> PaintFallback<'a> {
+    /// Parses a `PaintFallback` from a string.
+    ///
+    /// We can't use the `FromStr` trait because it requires
+    /// an owned value as a return type.
+    #[allow(clippy::should_implement_trait)]
+    fn from_str(text: &'a str) -> Result<Self, Error> {
+        let text = text.trim();
+        match text {
+            "" => return Ok(PaintFallback::Empty),
+            "none" => return Ok(PaintFallback::None),
+            "currentColor" =>return Ok( PaintFallback::CurrentColor),
+            _ => {}
+        }
+
+        let mut s = Stream::from(text);
+        if s.starts_with(b"var(") {
+            let (variable, fallback) = s.parse_var_func()?;
+            let fallback = match fallback {
+                None => None,
+                Some("") => Some(Box::new(PaintFallback::Empty)),
+                Some(other) => Some(Box::new(PaintFallback::from_str(other)?))
+            };
+            return Ok(PaintFallback::Variable(variable, fallback));
+        }
+
+        Color::from_str(text).map(PaintFallback::Color)
+    }
 }
 
 /// Representation of the [`<paint>`] type.
@@ -39,7 +77,7 @@ pub enum PaintFallback {
 /// let paint = Paint::from_str("inherit").unwrap();
 /// assert_eq!(paint, Paint::Inherit);
 /// ```
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Paint<'a> {
     /// The `none` value.
     None,
@@ -54,11 +92,15 @@ pub enum Paint<'a> {
     /// [`<FuncIRI>`] value with an optional fallback.
     ///
     /// [`<FuncIRI>`]: https://www.w3.org/TR/SVG11/types.html#DataTypeFuncIRI
-    FuncIRI(&'a str, Option<PaintFallback>),
+    FuncIRI(&'a str, Option<PaintFallback<'a>>),
     /// The `context-fill` value.
     ContextFill,
     /// The `context-stroke` value.
     ContextStroke,
+    /// A `var()` function.
+    /// 
+    /// See [`VariableFunction`] for details.
+    Variable(&'a str, Option<PaintFallback<'a>>),
 }
 
 impl<'a> Paint<'a> {
@@ -70,44 +112,40 @@ impl<'a> Paint<'a> {
     pub fn from_str(text: &'a str) -> Result<Self, Error> {
         let text = text.trim();
         match text {
-            "none" => Ok(Paint::None),
-            "inherit" => Ok(Paint::Inherit),
-            "currentColor" => Ok(Paint::CurrentColor),
-            "context-fill" => Ok(Paint::ContextFill),
-            "context-stroke" => Ok(Paint::ContextStroke),
-            _ => {
-                let mut s = Stream::from(text);
-                if s.starts_with(b"url(") {
-                    match s.parse_func_iri() {
-                        Ok(link) => {
-                            s.skip_spaces();
-
-                            // get fallback
-                            if !s.at_end() {
-                                let fallback = s.slice_tail();
-                                match fallback {
-                                    "none" => Ok(Paint::FuncIRI(link, Some(PaintFallback::None))),
-                                    "currentColor" => {
-                                        Ok(Paint::FuncIRI(link, Some(PaintFallback::CurrentColor)))
-                                    }
-                                    _ => {
-                                        let color = Color::from_str(fallback)?;
-                                        Ok(Paint::FuncIRI(link, Some(PaintFallback::Color(color))))
-                                    }
-                                }
-                            } else {
-                                Ok(Paint::FuncIRI(link, None))
-                            }
-                        }
-                        Err(_) => Err(Error::InvalidValue),
-                    }
-                } else {
-                    match Color::from_str(text) {
-                        Ok(c) => Ok(Paint::Color(c)),
-                        Err(_) => Err(Error::InvalidValue),
-                    }
-                }
+            "none" => return Ok(Paint::None),
+            "inherit" => return Ok(Paint::Inherit),
+            "currentColor" => return Ok(Paint::CurrentColor),
+            "context-fill" => return Ok(Paint::ContextFill),
+            "context-stroke" => return Ok(Paint::ContextStroke),
+            _ => {}
+        }
+        let mut s = Stream::from(text);
+        if s.starts_with(b"url(") {
+            let link = s.parse_func_iri()?;
+            s.skip_spaces();
+            // get fallback
+            if !s.at_end() {
+                let fallback = s.slice_tail();
+                let fallback = PaintFallback::from_str(fallback)?;
+                return Ok(Paint::FuncIRI(link, Some(fallback)));
+            } else {
+                return Ok(Paint::FuncIRI(link, None));
             }
+        }
+
+        if s.starts_with(b"var(") {
+            let (variable, fallback) = s.parse_var_func()?;
+            let fallback = match fallback {
+                None => None,
+                Some("") => Some(PaintFallback::Empty),
+                Some(other) => Some(PaintFallback::from_str(other)?)
+            };
+            return Ok(Paint::Variable(variable, fallback));
+        }
+        
+        match Color::from_str(text) {
+            Ok(c) => Ok(Paint::Color(c)),
+            Err(_) => Err(Error::InvalidValue),
         }
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -172,6 +172,31 @@ impl<'a> Stream<'a> {
         self.text[self.pos..].chars()
     }
 
+    /// Returns a zero-length string at current position.
+    pub fn curr_empty(&self) -> &'a str {
+        &self.text[self.pos..self.pos]
+    }
+
+    /// Returns a string that starts at given `start` position and ends at
+    /// current position.
+    /// 
+    /// # Panics
+    /// 
+    /// This function will panic if provided `start` string is not found in this
+    /// stream.
+    pub fn terminate_start(&self, start: &'a str) -> &'a str {
+        let start_pos = start.as_bytes().as_ptr_range().start;
+        if !self.text.as_bytes().as_ptr_range().contains(&start_pos) {
+            panic!("tried terminating a string that doesn't belong to this stream")
+        }
+        let start_offset = {
+            // SAFETY: Checked whether self.text contains start_pos above, so
+            // it's larger or equal to first byte in the stream.
+            start_pos as usize - self.text.as_bytes().as_ptr_range().start as usize
+        };
+        &self.text[start_offset..self.pos]
+    }
+
     /// Returns a byte from a current stream position.
     ///
     /// # Panics

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -1,0 +1,178 @@
+//! Parsing for [CSS Variables Level 1].
+//!
+//! [CSS Variables Level 1]: https://www.w3.org/TR/css-variables-1
+
+use crate::stream::Stream;
+use crate::Error;
+use std::marker::PhantomData;
+
+/// Fallback values for [variable] functions.
+/// 
+/// [variable]: https://www.w3.org/TR/css-variables-1/#using-variables
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VariableFallback<'a> {
+    /// No fallback specified.
+    /// 
+    /// Discard the rule on substitution failure.
+    None,
+    /// Empty fallback is specified.
+    /// 
+    /// Treat as empty value on substitution failure.
+    Empty(PhantomData<&'a str>),
+    /// Fallback is specified.
+    /// 
+    /// Use the fallback on substitution failure.
+    Some(&'a str),
+}
+
+impl<'a> From<Option<&'a str>> for VariableFallback<'a> {
+    fn from(value: Option<&'a str>) -> Self {
+        match value {
+            Some("") => VariableFallback::Empty(PhantomData),
+            Some(not_empty) => VariableFallback::Some(not_empty),
+            None => VariableFallback::None,
+        }
+    }
+}
+
+/// Arbitrary substitution function with optional fallback ([`var()`]).
+/// 
+/// [`var()`]: https://drafts.csswg.org/css-variables/#funcdef-var
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VariableFunction<'a> {
+    pub variable: &'a str,
+    pub fallback: VariableFallback<'a>
+}
+
+impl<'a> VariableFunction<'a> {
+    /// Parsers a `Variable` from a string.
+    ///
+    /// We can't use the `FromStr` trait because it requires
+    /// an owned value as a return type.
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(text: &'a str) -> Result<Self, Error> {
+        let mut s = Stream::from(text);
+        let (variable, fallback) = s.parse_var_func()?;
+        Ok(VariableFunction {
+            variable,
+            fallback: VariableFallback::from(fallback)
+        })
+    }
+}
+
+impl<'a> Stream<'a> {
+    /// Parses a single [custom property] identifier.
+    ///
+    /// It's expected to start with double dash ("--").
+    ///
+    /// [custom property]: https://www.w3.org/TR/css-variables-1/#defining-variables
+    pub fn parse_custom_property(&mut self) -> Result<&'a str, Error> {
+        self.skip_spaces();
+        if !self.starts_with(b"--") {
+            return Err(Error::InvalidIdent);
+        }
+        let name = self.consume_bytes(|_, c| !c.is_ascii_whitespace());
+        if name.is_empty() {
+            // only "--" is reserved by the spec for future use
+            Err(Error::InvalidValue)
+        } else {
+            Ok(name)
+        }
+    }
+
+    pub fn parse_var_func(&mut self) -> Result<(&'a str, Option<&'a str>), Error> {
+        // https://www.w3.org/TR/css-variables-1/#syntax
+        // var() = var( <custom-property-name> , <declaration-value>? )
+
+        self.skip_spaces();
+        self.consume_string(b"var(")?;
+        self.skip_spaces();
+
+        let custom_property_name = self.parse_custom_property()?;
+
+        self.skip_spaces();
+        if self.curr_byte()? != b',' {
+            self.consume_byte(b')')?;
+            return Ok((custom_property_name, None));
+        } else {
+            self.advance(1);
+            self.skip_spaces();
+        };
+
+        let mut declaration_value = Some(self.curr_empty());
+        if self.curr_byte()? == b')' {
+            // https://www.w3.org/TR/css-variables-1/#using-variables
+            // var(--a,) is a valid function, specifying that if the --a custom
+            // property is invalid or missing, the var() should be replaced with
+            // nothing
+            return Ok((custom_property_name, declaration_value));
+        }
+
+        // The <declaration-value> production matches any sequence of one or
+        // more tokens, so long as the sequence does not contain
+        // <bad-string-token>, <bad-url-token>, unmatched <)-token>, <]-token>,
+        // or <}-token>, or top-level <semicolon-token> tokens or <delim-token>
+        // tokens with a value of "!".
+
+        let mut wrap = Vec::new();
+        loop {
+            match self.next_byte()? {
+                b'(' => wrap.push(b')'),
+                b'[' => wrap.push(b']'),
+                b'{' => wrap.push(b']'),
+                b'"' | b'\'' => {
+                    // check for <bad-string-token>
+                    self.parse_quoted_string()?;
+                },
+                b'u' if self.starts_with(b"url(") => {
+                    // check for <bad-url-token>
+                    self.parse_func_iri()?;
+                }
+                b')' => match wrap.last() {
+                    Some(b')') => {
+                        wrap.pop();
+                    }
+                    // unmatched <)-token>
+                    Some(_) => return Err(Error::InvalidValue),
+                    // <declaration-value> termination
+                    None => {
+                        declaration_value =
+                            declaration_value.map(|start| self.terminate_start(start).trim_end());
+                        break;
+                    }
+                },
+                b']' => match wrap.last() {
+                    Some(b']') => {
+                        wrap.pop();
+                    }
+                    // unmatched <]-token>
+                    Some(_) | None => return Err(Error::InvalidValue),
+                },
+                b'}' => match wrap.last() {
+                    Some(b'}') => {
+                        wrap.pop();
+                    }
+                    // unmatched <}-token>
+                    Some(_) | None => return Err(Error::InvalidValue),
+                },
+                // top-level <semicolon-token> token
+                b';' if wrap.is_empty() => {
+                    return Err(Error::InvalidValue)
+                }
+                // top-level <delim-token> token with value '!'
+                b'!' if wrap.is_empty() => {
+                    return Err(Error::InvalidValue)
+                }
+                _ => {}
+            }
+            self.advance(1);
+        }
+
+        Ok((custom_property_name, declaration_value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO: Add tests
+}


### PR DESCRIPTION
Adds support for parsing [CSS Variables Level 1](https://www.w3.org/TR/css-variables-1).

This PR is a prerequisite for [resvg#821](https://github.com/linebender/resvg/issues/821).
