### PR TITLE
Round hues in HSL to RGB conversion

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -563,13 +563,13 @@ mod tests {
     test!(
         hsl_with_hue_float,
         "hsl(120.152, 100%, 75%)",
-        Color::new_rgba(127, 255, 127, 255)
+        Color::new_rgba(128, 255, 128, 255)
     );
 
     test!(
         hsla_with_hue_float,
         "hsla(120.152, 100%, 75%, 0.5)",
-        Color::new_rgba(127, 255, 127, 127)
+        Color::new_rgba(128, 255, 128, 127)
     );
 
     macro_rules! test_err {

--- a/src/color.rs
+++ b/src/color.rs
@@ -273,9 +273,9 @@ fn hsl_to_rgb(hue: f32, saturation: f32, lightness: f32) -> Color {
     let green = hue_to_rgb(t1, t2, hue);
     let blue = hue_to_rgb(t1, t2, hue - 2.0);
     Color::new_rgb(
-        (red * 255.0) as u8,
-        (green * 255.0) as u8,
-        (blue * 255.0) as u8,
+        (red * 255.0).round() as u8,
+        (green * 255.0).round() as u8,
+        (blue * 255.0).round() as u8,
     )
 }
 
@@ -521,7 +521,7 @@ mod tests {
     test!(
         hsl_green,
         "hsl(120, 100%, 75%)",
-        Color::new_rgba(127, 255, 127, 255)
+        Color::new_rgba(128, 255, 128, 255)
     );
 
     test!(
@@ -545,13 +545,19 @@ mod tests {
     test!(
         hsla_green,
         "hsla(120, 100%, 75%, 0.5)",
-        Color::new_rgba(127, 255, 127, 127)
+        Color::new_rgba(128, 255, 128, 127)
     );
 
     test!(
         hsl_with_alpha,
         "hsl(120, 100%, 75%, 0.5)",
-        Color::new_rgba(127, 255, 127, 127)
+        Color::new_rgba(128, 255, 128, 127)
+    );
+
+    test!(
+        hsl_to_rgb_red_round_up,
+        "hsl(230, 57%, 54%)",
+        Color::new_rgba(71, 93, 205, 255)
     );
 
     test!(


### PR DESCRIPTION
The current float to integer cast truncates the hues when converting from HSL to RGB. This PR rounds to the nearest integer before the cast. 

See https://github.com/linebender/resvg/issues/786 for discussion.

Modifies tests with `hsl(120, 100%, 75%, 0.5)` to match with `rgb(128, 255, 128)` and adds one new test case.

Chrome developer tools:
<img width="485" alt="Screenshot 2024-12-02 at 11 00 54 PM" src="https://github.com/user-attachments/assets/bddba238-3ed5-4b76-bbc6-d3823e205d57">

Safari developer tools:
<img width="659" alt="Screenshot 2024-12-02 at 11 06 15 PM" src="https://github.com/user-attachments/assets/32055547-0c12-4bd8-a917-20574dcb1ac2">
