### PR TITLE
Set MSRV in Cargo.toml, bump Rust edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,9 @@ description = "SVG types parser."
 documentation = "https://docs.rs/svgtypes/"
 keywords = ["svg", "parser", "tokenizer"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
+edition = "2021"
+# Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml
+rust-version = "1.65"
 readme = "README.md"
 repository = "https://github.com/RazrFalcon/svgtypes"
 exclude = ["benches/", "codegen/", "fuzz/"]


### PR DESCRIPTION
The MSRV is set to the lowest Rust version currently used in CI and allows for some code changes after this PR. The MSRV is equal to usvg's.

The edition bump is not necessary for anything immediately, but also doesn't require any other changes.