### PR TITLE
Use f64::clamp

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -310,7 +310,7 @@ fn f64_bound(min: f64, val: f64, max: f64) -> f64 {
     debug_assert!(min.is_finite());
     debug_assert!(val.is_finite());
     debug_assert!(max.is_finite());
-    val.max(min).min(max)
+    val.clamp(min, max)
 }
 
 #[rustfmt::skip]

--- a/src/color.rs
+++ b/src/color.rs
@@ -307,9 +307,7 @@ fn bound<T: Ord>(min: T, val: T, max: T) -> T {
 
 #[inline]
 fn f64_bound(min: f64, val: f64, max: f64) -> f64 {
-    debug_assert!(min.is_finite());
     debug_assert!(val.is_finite());
-    debug_assert!(max.is_finite());
     val.clamp(min, max)
 }
 


### PR DESCRIPTION
Stabilized in Rust 1.50, and resvg now has MSRV 1.65.