### PR TITLE
benches: Mark crate as not published

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -3,6 +3,7 @@ name = "benchmark"
 version = "0.1.0"
 edition = "2018"
 workspace = ".."
+publish = false
 
 [dependencies]
 svgtypes = { path = "../" }


### PR DESCRIPTION
This prevents some warnings from clippy about project metadata being missing.